### PR TITLE
Message headers fix for to, cc, and bcc fields

### DIFF
--- a/mailshake/message.py
+++ b/mailshake/message.py
@@ -75,11 +75,18 @@ class EmailMessage(object):
         msg = self._create_message()
         msg['Subject'] = self.subject
         msg['From'] = self.extra_headers.get('From', self.from_email)
-        msg['To'] = ', '.join(self.to)
+
+        if not self.get_recipients():
+            # TODO:
+            # No logger has been included, so in this case just let the email
+            # fail during sending.
+            pass
+
+        if self.to:
+            msg['To'] = ', '.join(self.to)
+
         if self.cc:
             msg['Cc'] = ', '.join(self.cc)
-        if self.bcc:
-            msg['Bcc'] = ', '.join(self.bcc)
 
         # Email header names are case-insensitive (RFC 2045), so we have to
         # accommodate that when doing comparisons.


### PR DESCRIPTION
- You should not be required to specify a "to"-address if there are "cc" or "bcc" addresses also specified.  All three of these fields are optional (assuming at least one of them is present).  Restructured the `Message.message` method a bit to accomodate for this.
- Also removed "bcc" from being displayed in the message headers.  If you include them, the recipient of the message will be able to see the other individuals the message was sent to, thus defeating the purpose of using a blind-carbon copy.

Tests pass and it works.
