### PR TITLE
Fix and clean up the email address encoding

### DIFF
--- a/mailshake/message.py
+++ b/mailshake/message.py
@@ -12,7 +12,7 @@ import os
 
 import html2text
 
-from .utils import sanitize_address, forbid_multi_line_headers, make_msgid, to_str
+from .utils import encode_address, forbid_multi_line_headers, make_msgid, to_str
 
 
 textify = html2text.HTML2Text()
@@ -132,23 +132,21 @@ class EmailMessage(object):
         to = to or []
         if isinstance(to, str):
             to = [to]
-        self.to = [sanitize_address(to_str(_to), encoding) for _to in list(to)]
+        self.to = [encode_address(addr, self.encoding) for addr in to]
         cc = cc or []
         if isinstance(cc, str):
             cc = [cc]
-        self.cc = [sanitize_address(to_str(_cc), encoding) for _cc in list(cc)]
+        self.cc = [encode_address(addr, self.encoding) for addr in cc]
 
         bcc = bcc or []
         if isinstance(bcc, str):
             bcc = [bcc]
-        self.bcc = [sanitize_address(to_str(_bcc), encoding) for _bcc in list(bcc)]
+        self.bcc = [encode_address(addr, self.encoding) for addr in bcc]
 
         reply_to = reply_to or []
         if isinstance(reply_to, str):
             reply_to = [reply_to]
-        self.reply_to = [
-            sanitize_address(to_str(rt), encoding) for rt in list(reply_to)
-        ]
+        self.reply_to = [encode_address(addr, self.encoding) for addr in reply_to]
 
         self.from_email = from_email
         self.subject = subject

--- a/mailshake/utils.py
+++ b/mailshake/utils.py
@@ -2,12 +2,14 @@
 Adapted from Django (http://djangoproject.com).
 The original code was BSD licensed (see LICENSE)
 """
+from email.charset import Charset
 from email.header import Header
-from email.utils import parseaddr, getaddresses
+from email.utils import formataddr, getaddresses, parseaddr
 import os
 import random
 import socket
 import time
+import warnings
 
 
 class CachedDnsName(object):
@@ -28,58 +30,50 @@ DNS_NAME = CachedDnsName()
 
 
 def split_addr(addr, encoding):
-    """
-    Split the address into local part and domain, properly encoded.
+    warnings.warn(
+        "the split_addr function is deprecated, you can use a simple "
+        "`.rsplit('@', 1)` instead", DeprecationWarning
+    )
+    return encode_address(addr, encoding).rsplit("@", 1)
 
-    When non-ascii characters are present in the local part, it must be
-    MIME-word encoded. The domain name must be idna-encoded if it contains
+
+def encode_address(addr, charset):
+    """Encode a pair of (name, address) or an email address string.
+
+    When non-ascii characters are present in the name or local part, they're
+    MIME-word encoded. The domain name is idna-encoded if it contains
     non-ascii characters.
     """
+    if not isinstance(addr, tuple):
+        addr = parseaddr(to_str(addr))
+    name, addr = addr
+    if isinstance(charset, str):
+        charset = Charset(charset)
     if "@" in addr:
-        localpart, domain = addr.split("@", 1)
+        localpart, domain = addr.rsplit("@", 1)
         # Try to get the simplest encoding - ascii if possible so that
         # to@example.com doesn't become =?utf-8?q?to?=@example.com. This
         # makes unit testing a bit easier and more readable.
         try:
             localpart.encode("ascii")
         except UnicodeEncodeError:
-            localpart = Header(localpart, encoding).encode()
-        domain = domain.encode("idna").decode("ascii")
+            localpart = charset.header_encode(localpart)
+        addr = localpart + "@" + domain.encode("idna").decode("ascii")
+        del localpart, domain
     else:
-        localpart = Header(addr, encoding).encode()
-        domain = ""
-    return (localpart, domain)
+        try:
+            addr.encode("ascii")
+        except UnicodeEncodeError:
+            addr = charset.header_encode(addr)
+    return formataddr((name, addr), charset=charset)
 
 
 def sanitize_address(addr, encoding):
-    """
-    Format a pair of (name, address) or an email address string.
-    """
-    if not isinstance(addr, tuple):
-        addr = parseaddr(to_str(addr))
-    nm, addr = addr
-    localpart, domain = None, None
-    nm = Header(nm, encoding).encode()
-    try:
-        addr.encode("ascii")
-    except UnicodeEncodeError:  # IDN or non-ascii in the local part
-        localpart, domain = split_addr(addr, encoding)
-
-    # On Python 3, an `email.headerregistry.Address` object is used since
-    # email.utils.formataddr() naively encodes the name as ascii (see #25986).
-    from email.headerregistry import Address
-    from email.errors import InvalidHeaderDefect, NonASCIILocalPartDefect
-
-    if localpart and domain:
-        address = Address(nm, username=localpart, domain=domain)
-        return str(address)
-
-    try:
-        address = Address(nm, addr_spec=addr)
-    except (InvalidHeaderDefect, NonASCIILocalPartDefect):
-        localpart, domain = split_addr(addr, encoding)
-        address = Address(nm, username=localpart, domain=domain)
-    return str(address)
+    warnings.warn(
+        "the sanitize_address function has been replaced by encode_address",
+        DeprecationWarning
+    )
+    return encode_address(addr, encoding)
 
 
 def make_msgid(idstring=None):
@@ -138,7 +132,7 @@ def forbid_multi_line_headers(name, val, encoding="utf-8"):
     except UnicodeEncodeError:
         if name.lower() in ADDRESS_HEADERS:
             val = ", ".join(
-                [sanitize_address(addr, encoding) for addr in getaddresses((val,))]
+                [encode_address(addr, encoding) for addr in getaddresses((val,))]
             )
         else:
             val = Header(val, encoding).encode()

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -271,6 +271,18 @@ def test_unicode_address_header():
         == "other@example.com, =?utf-8?q?S=C3=BCrname=2C_Firstname?= <to@example.com>"
     )
 
+    email = EmailMessage(
+        "Subject",
+        "Content",
+        "from@example.com",
+        ["other@example.com", "à" * 50 + " <to@example.com>"],
+    )
+    message = email.render()
+    assert (
+        message["To"]
+        == "other@example.com, " + "=?utf-8?b?" + "w6DDoMOg" * 16 + "w6DDoA==?= <to@example.com>"
+    )
+
 
 def test_unicode_headers():
     headers = {


### PR DESCRIPTION
This branch deprecates the `split_addr` and `sanitize_address` functions and replaces them with a new `encode_address` function.

The current code uses the `Header(…).encode()` method in a way that causes an error when attempting to send a message to someone with a long non-ASCII name:

```python-traceback
Traceback (most recent call last):
  …
  File "lib/python3.6/site-packages/mailshake/message.py", line 172, in render
    msg["To"] = ", ".join(self.to)
  File "lib/python3.6/site-packages/mailshake/message.py", line 88, in __setitem__
    name, val = forbid_multi_line_headers(name, val, self.encoding)
  File "lib/python3.6/site-packages/mailshake/utils.py", line 134, in forbid_multi_line_headers
    "(got {val} for header {name})".format(val=val, name=name)
ValueError: Header values can't contain newlines (got =?utf-8?b?PT91dGYtOD9xP0ZyPUMzPUE5ZD1DMz1BOXJpY19kPTI3QXJ1bmRlbF9kPTI3RXNx?=
 =?utf-8?b?dWluY291cnRfZGVfQ29uZD1DMz1BOT89?= <frederic@example.org> for header To)
```