### PR TITLE
Flake8

### DIFF
--- a/mailshake/utils.py
+++ b/mailshake/utils.py
@@ -96,7 +96,7 @@ def make_msgid(idstring=None):
     else:
         idstring = "." + idstring
     idhost = DNS_NAME
-    msgid = "<{}.{}.{}@{}>".format(utcdate, pid, randint, idstring, idhost)
+    msgid = "<{}.{}.{}{}@{}>".format(utcdate, pid, randint, idstring, idhost)
     return msgid
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ exclude =
 [options.extras_require]
 testing =
     pytest
+    flake8
 
 dev =
     pytest

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -278,9 +278,9 @@ def test_unicode_address_header():
         ["other@example.com", "à" * 50 + " <to@example.com>"],
     )
     message = email.render()
-    assert (
-        message["To"]
-        == "other@example.com, " + "=?utf-8?b?" + "w6DDoMOg" * 16 + "w6DDoA==?= <to@example.com>"
+    assert message["To"] == (
+        "other@example.com, "
+        + "=?utf-8?b?" + "w6DDoMOg" * 16 + "w6DDoA==?= <to@example.com>"
     )
 
 

--- a/tests/test_smtp_mailer.py
+++ b/tests/test_smtp_mailer.py
@@ -124,7 +124,9 @@ def test_fail_silently():
     )
     mailer.open()
 
-    mailer = SMTPMailer(host="123", port=SMTP_PORT, use_tls=False, fail_silently=True, timeout=0.5)
+    mailer = SMTPMailer(
+        host="123", port=SMTP_PORT, use_tls=False, fail_silently=True, timeout=0.5
+    )
     mailer.open()
 
     mailer = SMTPMailer(host="127.0.0.1", port=3000, use_tls=False, fail_silently=True)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ skip_install = true
 commands =
 	pip install -U pip
 	pip install .[testing]
-    pytest -x mailshake tests
+    python -m pytest -x mailshake tests
+    python -m flake8
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
This branch adds a flake8 run to the automated testing, and fixes a significant bug detected by flake8: the `Message-ID` generator is broken.