### PR TITLE
Test and improve the Message-ID generator

### DIFF
--- a/mailshake/utils.py
+++ b/mailshake/utils.py
@@ -2,13 +2,13 @@
 Adapted from Django (http://djangoproject.com).
 The original code was BSD licensed (see LICENSE)
 """
+from datetime import datetime
 from email.charset import Charset
 from email.header import Header
 from email.utils import formataddr, getaddresses, parseaddr
 import os
 import socket
 import threading
-import time
 import warnings
 
 
@@ -92,8 +92,7 @@ def make_msgid(idstring=None, host_id=DNS_NAME):
     By default the name returned by `socket.getfqdn()` is used, however it isn't
     guaranteed to be globally unique.
     """
-    timeval = time.time()
-    utcdate = time.strftime("%Y%m%d%H%M%S", time.gmtime(timeval))
+    utcdate = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     try:
         pid = os.getpid()
     except AttributeError:

--- a/mailshake/utils.py
+++ b/mailshake/utils.py
@@ -79,13 +79,18 @@ def sanitize_address(addr, encoding):
 thread_lock = threading.Lock()
 
 
-def make_msgid(idstring=None):
+def make_msgid(idstring=None, host_id=DNS_NAME):
     """Returns a string suitable for RFC 2822 compliant Message-ID, e.g:
 
     <20200818100350.554898.7effb56bc790.44@mail.example.com>
 
-    Optional idstring if given is a string used to strengthen the
-    uniqueness of the message id.
+    The optional idstring argument is used to strengthen the uniqueness of the
+    message id.
+
+    The optional host_id argument allows you to specify the last part of the
+    message ID. It must be a globally unique ID, preferably a valid domain name.
+    By default the name returned by `socket.getfqdn()` is used, however it isn't
+    guaranteed to be globally unique.
     """
     timeval = time.time()
     utcdate = time.strftime("%Y%m%d%H%M%S", time.gmtime(timeval))
@@ -104,9 +109,8 @@ def make_msgid(idstring=None):
         idstring = ""
     else:
         idstring = "." + idstring
-    idhost = DNS_NAME
     return "<{}.{}.{:x}.{}{}@{}>".format(
-        utcdate, pid, function_id, sequence_id, idstring, idhost
+        utcdate, pid, function_id, sequence_id, idstring, host_id
     )
 
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from ..mailshake import EmailMessage
@@ -496,3 +498,14 @@ def test_invalid_destination():
     assert message.get_payload() == "Content"
     assert message["From"] == "from@example.com"
     assert message["To"] != dest
+
+
+def test_message_id():
+    message_id_re = re.compile(r"^<[0-9]{14}\.[0-9]+\.[0-9]+@[a-z\-]+(\.[a-z\-]+)*>$")
+    email1 = EmailMessage("Subject 1", "Content", "from@example.com", "to@example.com")
+    msg1 = email1.render()
+    assert message_id_re.match(msg1["Message-ID"])
+    email2 = EmailMessage("Subject 2", "Content", "from@example.com", "to@example.com")
+    msg2 = email2.render()
+    assert message_id_re.match(msg2["Message-ID"])
+    assert msg2["Message-ID"] != msg1["Message-ID"]

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -501,7 +501,9 @@ def test_invalid_destination():
 
 
 def test_message_id():
-    message_id_re = re.compile(r"^<[0-9]{14}\.[0-9]+\.[0-9]+@[a-z\-]+(\.[a-z\-]+)*>$")
+    message_id_re = re.compile(
+        r"^<[0-9]{14}\.[0-9]+\.[0-9a-f]+\.[0-9]+@[a-z\-]+(\.[a-z\-]+)*>$"
+    )
     email1 = EmailMessage("Subject 1", "Content", "from@example.com", "to@example.com")
     msg1 = email1.render()
     assert message_id_re.match(msg1["Message-ID"])


### PR DESCRIPTION
This branch modifies the `make_msgid` function so that it never produces two identical IDs for two different messages. The random number is replaced by a sequence number, and the ID of the generating function is added so that other functions within the same Python process could generate message IDs in the same way.