### PR TITLE
Fix the `Charset` values in the SES mailer

### DIFF
--- a/mailshake/mailers/amazon_ses.py
+++ b/mailshake/mailers/amazon_ses.py
@@ -51,15 +51,15 @@ class AmazonSESMailer(BaseMailer):
             if msg.bcc:
                 destination_data["BccAddresses"] = msg.bcc
 
-            body_data = {"Text": {"Data": msg.text, "Charset": "utf8"}}
+            body_data = {"Text": {"Data": msg.text, "Charset": "UTF-8"}}
             if msg.html:
-                body_data["Html"] = {"Data": msg.html, "Charset": "utf8"}
+                body_data["Html"] = {"Data": msg.html, "Charset": "UTF-8"}
 
             data = {
                 "Source": msg.from_email,
                 "Destination": destination_data,
                 "Message": {
-                    "Subject": {"Data": msg.subject, "Charset": "utf8"},
+                    "Subject": {"Data": msg.subject, "Charset": "UTF-8"},
                     "Body": body_data,
                 },
             }


### PR DESCRIPTION
The standard name is `UTF-8`. The dash-less variant `utf8` does not exist in [the IANA registry](https://www.iana.org/assignments/character-sets/character-sets.xhtml), so it might not be understood by all email clients. I'm thinking that this irregularity could be the cause of <https://github.com/liberapay/liberapay.com/issues/2239>. The [example in boto3's documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses/client/send_email.html) uses `UTF-8`.